### PR TITLE
Add identifier attribute for source tables

### DIFF
--- a/models/claims/schema/source.yml
+++ b/models/claims/schema/source.yml
@@ -6,6 +6,7 @@ sources:
     schema:  "{{ var('input_schema') }}"
     tables:
       - name: eligibility
+        identifier: tuva_input_eligibility
         description: >
           Year-month eligibility data per patient and payer.
         columns:
@@ -53,6 +54,7 @@ sources:
 
 
       - name: medical_claim
+        identifier: tuva_input_claims
         description: >
           Line-level claims data, including revenue and HCPCS codes where each claim id and claim line number is unique.
         columns:


### PR DESCRIPTION
## Describe your changes
This PR adds the `identifier` property to the source.yml file for each source table. This change is necessary as the input table names (`tuva_input_eligibility` and `tuva_input_claims`) differ from the Tuva Claims data model.

## Validation & Testing
Tested locally with the following dbt command. 

```
dbt build --vars '{ input_database: transformed_data, input_schema: prod_base, output_database: transformed_data, output_schema: prod_tuva, terminology_schema: prod_tuva }'
```
